### PR TITLE
New Feature: handle pointer fields

### DIFF
--- a/structable.go
+++ b/structable.go
@@ -494,6 +494,9 @@ func (s *DbRecorder) colList(withKeys bool, omitNil bool) []string {
 	return names
 }
 
+// fieldReferences gets a list of references to the record values, so that the
+// caller can modify them. If withKeys is false, columns that are designated as
+// primary keys will not be returned in this list.
 func (s *DbRecorder) fieldReferences(withKeys bool) []interface{} {
 	refs := make([]interface{}, 0, len(s.fields))
 

--- a/structable.go
+++ b/structable.go
@@ -332,7 +332,7 @@ func (s *DbRecorder) Load() error {
 // 		return s.LoadWhere("uuid = ?", uuid)
 // 	}
 //
-// This functions similarly to Load, but with the notable differance that
+// This functions similarly to Load, but with the notable difference that
 // it loads the entire object (it does not skip keys used to do the lookup).
 func (s *DbRecorder) LoadWhere(pred interface{}, args ...interface{}) error {
 	dest := s.fieldReferences(true)
@@ -357,6 +357,10 @@ func (s *DbRecorder) Exists() (bool, error) {
 	return has, err
 }
 
+// ExistsWhere returns `true` if and only if there is at least one record that matches one (or multiple) conditions.
+//
+// Conditions are expressed in the form of predicates and expected values
+// that together build a WHERE clause. See Squirrel's Where(pred, args)
 func (s *DbRecorder) ExistsWhere(pred interface{}, args ...interface{}) (bool, error) {
 	has := false
 


### PR DESCRIPTION
I'm proposing a new feature for **Structable**, the handling of **pointer fields**.

The main advantage to have this feature implemented in Structable is that pointer fields play well when you want to hide (or not include) some fields of a structure, before marshall it into JSON, or more generally to let a structure have different representations, depending on wether some pointer fields are nil. 

Let's take this struct as an example:

```
type User struct {
    Id       int     `stbl:"id,PRIMARY_KEY" json:"id"`
    Name     string  `stbl:"name"           json:"name"`
    Email    string  `stbl:"email"          json:"email"`
    Password *string `stbl:"email"          json:"password,omitempty"`
}
```

This hypothetical `User` struct can be used as-is for both database mapping (through Structable) and Json marshalling. Json `omitempty` requires the field to be a pointer, it is an easy way to represent the absence of a field. We can now have different representations of an User, one with the password being included and another with the password hidden. Some other use cases exist.
Some basic tests for pointer fields have been added to the existing test suite, they and included in this PR.

PS: I wrote a test suite, using an in-memory sqlite database backend, that could be considered as integration tests, however I didn't include it so as to keep focused the field of this PR focused on the feature. If you are interested I can push it here or in another PR.
